### PR TITLE
Improvements for cross-syncing multiple calendars

### DIFF
--- a/SyncCalendarsIntoOne.gs
+++ b/SyncCalendarsIntoOne.gs
@@ -16,6 +16,12 @@ const CALENDAR_TO_MERGE_INTO = 'target-calendar-id@gmail.com';
 // Number of days in the future to run.
 const DAYS_TO_SYNC = 30;
 
+// Ignore events with the same start and end datetime as existing events.
+// Assume they have been copied from the CALENDAR_TO_MERGE_INTO
+// when running the script on multiple accounts to cross-synchronize
+// calendars.
+const IGNORE_EVENTS_WITH_SAME_START_AND_END_DATETIME = true;
+
 // ----------------------------------------------------------------------------
 // DO NOT TOUCH FROM HERE ON
 // ----------------------------------------------------------------------------
@@ -29,6 +35,8 @@ function deleteCreatedEvents(startTime, endTime) {
     orderBy: 'startTime',
   });
 
+  const originalEvents = [];
+
   events.items.forEach((event) => {
     // Delete events with summary starting with IGNORE_TAG
     if (event.summary && String(event.summary).startsWith(IGNORE_TAG)) {
@@ -36,6 +44,8 @@ function deleteCreatedEvents(startTime, endTime) {
         method: 'DELETE',
         endpoint: `https://www.googleapis.com/calendar/v3/calendars/${CALENDAR_TO_MERGE_INTO}/events/${event.id}`
       })
+    } else {
+      originalEvents.push(event);
     }
   });
   
@@ -49,9 +59,11 @@ function deleteCreatedEvents(startTime, endTime) {
   } else {
     console.log('No events to delete.');
   }
+
+  return originalEvents;
 }
 
-function createEvents(startTime, endTime) {
+function createEvents(startTime, endTime, originalEvents) {
   let requestBody = [];
 
   for (let calenderName in CALENDARS_TO_MERGE) {
@@ -80,6 +92,10 @@ function createEvents(startTime, endTime) {
 
       // Don't copy "free" events.
       if (event.transparency && event.transparency === 'transparent') {
+        return;
+      }
+
+      if (IGNORE_EVENTS_WITH_SAME_START_AND_END_DATETIME && originalEvents.find(originalEvent => originalEvent.start.dateTime === event.start.dateTime && originalEvent.end.dateTime === event.end.dateTime)) {
         return;
       }
 
@@ -116,6 +132,6 @@ function SyncCalendarsIntoOne() {
   const endTime = new Date(startTime.valueOf());
   endTime.setDate(endTime.getDate() + DAYS_TO_SYNC);
 
-  deleteCreatedEvents(startTime, endTime);
-  createEvents(startTime, endTime);
+  const originalEvents = deleteCreatedEvents(startTime, endTime);
+  createEvents(startTime, endTime, originalEvents);
 }

--- a/SyncCalendarsIntoOne.gs
+++ b/SyncCalendarsIntoOne.gs
@@ -29,6 +29,10 @@ const IGNORE_EVENTS_WITH_SAME_START_AND_END_DATETIME = true;
 // Use `undefined` (without quotes) to use the default calendar color.
 const SYNCED_EVENTS_COLOR_ID = '5';
 
+// Whether the disable the default reminders (e.g. 10 mins before the event)
+// for created events.
+const DISABLE_REMINDERS = true;
+
 // ----------------------------------------------------------------------------
 // DO NOT TOUCH FROM HERE ON
 // ----------------------------------------------------------------------------
@@ -116,6 +120,9 @@ function createEvents(startTime, endTime, originalEvents) {
           start: event.start,
           end: event.end,
           colorId: SYNCED_EVENTS_COLOR_ID,
+          reminders: {
+            useDefault: !DISABLE_REMINDERS,
+          },
         },
       });
     });

--- a/SyncCalendarsIntoOne.gs
+++ b/SyncCalendarsIntoOne.gs
@@ -103,7 +103,7 @@ function createEvents(startTime, endTime, originalEvents) {
         method: 'POST',
         endpoint: `https://www.googleapis.com/calendar/v3/calendars/${CALENDAR_TO_MERGE_INTO}/events`,
         requestBody: {
-          summary: `${IGNORE_TAG} ${calenderName} ${event.summary}`,
+          summary: `${IGNORE_TAG} ${calenderName} ${event.summary || 'Busy'}`,
           location: event.location,
           description: event.description,
           start: event.start,

--- a/SyncCalendarsIntoOne.gs
+++ b/SyncCalendarsIntoOne.gs
@@ -22,6 +22,13 @@ const DAYS_TO_SYNC = 30;
 // calendars.
 const IGNORE_EVENTS_WITH_SAME_START_AND_END_DATETIME = true;
 
+// The ID of the color to use for created events.
+// Pick one from the `events` section of the following API:
+// https://developers.google.com/calendar/v3/reference/colors/get
+// You can use the "Try this API" right sidebar to see the exact values.
+// Use `undefined` (without quotes) to use the default calendar color.
+const SYNCED_EVENTS_COLOR_ID = '5';
+
 // ----------------------------------------------------------------------------
 // DO NOT TOUCH FROM HERE ON
 // ----------------------------------------------------------------------------
@@ -108,6 +115,7 @@ function createEvents(startTime, endTime, originalEvents) {
           description: event.description,
           start: event.start,
           end: event.end,
+          colorId: SYNCED_EVENTS_COLOR_ID,
         },
       });
     });


### PR DESCRIPTION
Awesome work finding and tuning this script :heart: 

I have added some options that make cross-syncing multiple calendars easier.

1. Do not create events that have the same start and end datetime as in the destination calendar.
    This is useful to have the events from the client's calendar visible in CodiLime's calendar, and original events from the CodiLime's calendar visible in the client's calendar without having the events listed multiple times :slightly_smiling_face: 
2. I have added support for setting the events' colors to easier distinguish them
3. I added an option to disable the default reminders to avoid having the same reminder twice from 2 different calendars